### PR TITLE
Configure FastAPI `default_response_class`, SQLAclhemy session with transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,35 @@
 * `Makefile` with commands for convenient usage.
 * CI workflow in GitHub Actions that starts with each commit into open PR into `develop` or `main` branches.
 
+## Optimization key points
+
+### SQLAlchemy
+* SQLAlchemy Connection Pooling with [AsyncAdaptedQueuePool](https://docs.sqlalchemy.org/en/20/core/pooling.html#sqlalchemy.pool.AsyncAdaptedQueuePool) allows to maintain connection to database.
+> [!NOTE]
+> `POOL_SIZE` and `MAX_OVERFLOW` environment variables should be set taking `uvicorn --workers N` into account.
+* `src.dependencies.get_session` provides AsyncGenerator of an [AsyncSession](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncSession) instance with the transaction that would be automatically committed or rolled back in case of any exception at the exit from the context manager.
+> [!NOTE]
+> DB connection is checked out from the pool at first `AsyncSession.execute` call and remains so until the exit from the context manager.
+
+### FastAPI
+* [ORJSONResponse](https://fastapi.tiangolo.com/advanced/custom-response/#orjsonresponse) as
+`default_response_class` in FastAPI configuration which uses the high-performance [orjson](https://github.com/ijl/orjson) library to serialize data to JSON.
+* [Middlewares](https://fastapi.tiangolo.com/tutorial/middleware/) are disabled, since usually the app runs behind a reverse proxy.
+* [src.healthcheck.router.healthcheck](src/healthcheck/router.py) returns [ORJSONResponse](https://fastapi.tiangolo.com/advanced/custom-response/#orjsonresponse)
+directly instead of the pydantic model [src.healthcheck.schemas.HealthCheckSchema](src/healthcheck/schemas.py) to avoid overcomplicated (_in some cases_) validation and serialization to an object compatible with JSON by [jsonable_encoder](https://fastapi.tiangolo.com/tutorial/encoder/).
+
+### Uvicorn
+When running uvicorn in production / stage environment behind a reverse proxy the start up command would be:
+```bash
+uvicorn src.main:app --host 0.0.0.0 --port 8000 --workers $UVICORN_WORKERS --loop uvloop --proxy-headers --no-access-log
+```
+* `--workers $UVICORN_WORKERS` - Set workers number according to number of vCPU of the server (as a start option).
+* `-loop uvloop` -  Set the event loop implementation to [uvloop](https://github.com/MagicStack/uvloop) explicitly (uvloop makes asyncio 2-4x faster).
+* `--proxy-headers` - Enable proxy headers.
+* `--no-access-log` - Disable uvicorn access log.
+
+> [!NOTE]
+> If uvicorn and a reverse proxy are running on the same server it is more beneficial to run establish a connection via UNIX domain socket with `--uds <path>` command (respectful configuration of a reverse proxy should be set).
 
 ## Use as Template
 

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,7 +1,8 @@
+# App
 MODE=LOCAL
-
-# Security
-CORS_ORIGINS=["*"]
+APP_NAME=FastAPI Template
+APP_VERSION=0.1.0
+UVICORN_WORKERS=1
 
 # Postgres
 POSTGRES_DB=postgres

--- a/src/.env.test
+++ b/src/.env.test
@@ -1,7 +1,8 @@
+# App
 MODE=TEST
-
-# Security
-CORS_ORIGINS=["*"]
+APP_NAME=FastAPI Template
+APP_VERSION=0.1.0
+UVICORN_WORKERS=1
 
 # Postgres
 POSTGRES_DB=postgres

--- a/src/api_config.py
+++ b/src/api_config.py
@@ -15,9 +15,6 @@ class ApiSettings(BaseSettings):
     APP_NAME: str = "app"
     APP_VERSION: str = "0.1.0"
 
-    # Security
-    CORS_ORIGINS: list[str] = ["*"]
-
     # Postgres
     POSTGRES_DB: str
     POSTGRES_USER: str

--- a/src/api_constants.py
+++ b/src/api_constants.py
@@ -4,7 +4,6 @@ from sqlalchemy import TextClause, text
 
 # MARK: Security
 ENV_PATH: str = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
-CORS_METHODS = ("DELETE", "GET", "OPTIONS", "PATCH", "POST", "PUT")
 
 # MARK: Database
 DB_NAMING_CONVENTION: dict[str, str] = {

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -11,14 +11,11 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
     AsyncGenerator of an `AsyncSession` instance.
 
     Note:
-    * The session would rollback automatically inside
-    the context manager in case of exception at closure.
-    * Connection is checkout from the pool at first call to the session.
-    * Commit must be done explicitly.
+    * The transaction would be automatically committed or rolled back
+    in case of any exception at the exit from the context manager.
+    * DB connection is checked out from the pool at first
+    `AsyncSession.execute` call and remains so until the exit from the context manager.
     """
 
-    async with SessionLocal() as session:
-        try:
-            yield session
-        except Exception as ex:
-            raise ex
+    async with SessionLocal.begin() as session:
+        yield session

--- a/src/healthcheck/router.py
+++ b/src/healthcheck/router.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, status
+from fastapi.responses import ORJSONResponse
 
+from src.api_config import api_settings
 from src.healthcheck.schemas import HealthCheckSchema
 
 __all__ = ["healthcheck_router"]
@@ -10,11 +12,16 @@ healthcheck_router = APIRouter(prefix="/healthcheck", tags=["Check API status"])
 @healthcheck_router.get(
     path="",
     summary="Check API status",
-    response_model=None,
-    status_code=status.HTTP_200_OK,
     responses={status.HTTP_200_OK: {"model": HealthCheckSchema}},
 )
-async def healthcheck() -> HealthCheckSchema:
+async def healthcheck() -> ORJSONResponse:
     """Check API status."""
 
-    return HealthCheckSchema()
+    return ORJSONResponse(
+        content={
+            "mode": api_settings.MODE,
+            "version": api_settings.APP_VERSION,
+            "status": "OK",
+        },
+        status_code=status.HTTP_200_OK,
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,6 @@
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, ORJSONResponse
 
-from src import api_constants
 from src.api_config import api_settings
 from src.healthcheck.router import healthcheck_router
 
@@ -17,16 +15,8 @@ app = FastAPI(
     docs_url="/docs" if api_settings.MODE != "PROD" else None,
     redoc_url="/redoc" if api_settings.MODE != "PROD" else None,
     openapi_url="/openapi.json" if api_settings.MODE != "PROD" else None,
+    default_response_class=ORJSONResponse,  # JSON response using the high-performance orjson library to serialize data to JSON
 )
-
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=api_settings.CORS_ORIGINS,
-    allow_credentials=True,
-    allow_methods=api_constants.CORS_METHODS,
-)
-
 
 routers = (healthcheck_router,)
 for router in routers:


### PR DESCRIPTION
- [x] Set  [ORJSONResponse](https://fastapi.tiangolo.com/advanced/custom-response/#orjsonresponse) as `default_response_class
`
  - Delete `CORSMiddleware` since the app usually runs behind a reverse proxy
  - `GET /healthcheck` router now returns `ORJSONResponse` directly to avoid overcomplicated (in some cases) validation and serialization to an object compatible with JSON by `jsonable_encoder`
- [x] FastAPI `get_session` dependency which provides SQLAclhemy [AsyncSession with transaction](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.async_sessionmaker.begin)
- [x] Add optimization key points to `README.md`